### PR TITLE
fixing bug in refreshAccessToken()

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,4 +1,4 @@
-name: PHP Composer
+name: Build
 
 on:
   push:
@@ -8,9 +8,7 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install dependencies
       if: steps.composer-cache.outputs.cache-hit != 'true'
-      run: composer install --prefer-dist --no-progress --no-suggest
+      run: composer install --prefer-dist --no-progress
     
     - name: PHP_CodeSniffer Check with Annotations
       uses: chekalsky/phpcs-action@v1.2.0

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -32,9 +32,3 @@ jobs:
     
     - name: PHP_CodeSniffer Check with Annotations
       uses: chekalsky/phpcs-action@v1.2.0
-
-    # Add a test script to composer.json, for instance: "test": "vendor/bin/phpunit"
-    # Docs: https://getcomposer.org/doc/articles/scripts.md
-
-    # - name: Run test suite
-    #   run: composer run-script test

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+vendor

--- a/README.md
+++ b/README.md
@@ -55,20 +55,18 @@ $params = [
 	'clientId' => 'aaasssss....',
 	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
 	'redirectUri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
-	'auth_url' => 'https://business.revolut.com/app-confirm', 
 	'accessToken' => $a_token->access_token,
 	'accessTokenExpires' => $a_token->expires,
 	'refreshToken' => $r_token->refresh_token,
 	'refreshTokenExpires' => $r_token->expires,
-	'saveAccessToken' => function ($access_token, $expires) use ($path2token) {file_put_contents($path2token, json_encode(['access_token' => $access_token, 'expires' => $expires]));},
-	'saveRefreshToken' => function ($refresh_token, $expires) use ($path2refresh_token) {file_put_contents($path2refresh_token, json_encode(['refresh_token' => $refresh_token, 'expires' => $expires]));},
+	'saveAccessTokenCb' => function ($access_token, $expires) use ($path2token) {file_put_contents($path2token, json_encode(['access_token' => $access_token, 'expires' => $expires]));},
+	'saveRefreshTokenCb' => function ($refresh_token, $expires) use ($path2refresh_token) {file_put_contents($path2refresh_token, json_encode(['refresh_token' => $refresh_token, 'expires' => $expires]));},
 	'logError' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
 
 // for debug you can use
 // $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
-// $params['authUrl'] = 'https://sandbox-business.revolut.com/app-confirm';
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
 ```
@@ -85,20 +83,18 @@ $params = [
 	'clientId' => 'aaasssss....',
 	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
 	'redirectUri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
-	'auth_url' => 'https://business.revolut.com/app-confirm', 
 	'accessToken' => '',
 	'accessTokenExpires' => '',
 	'refreshToken' => '',
 	'refreshTokenExpires' => '',
-	'saveAccessToken' => function ($access_token, $expires){},
-	'saveRefreshToken' => function ($refresh_token, $expires){},
+	'saveAccessTokenCb' => function ($access_token, $expires){},
+	'saveRefreshTokenCb' => function ($refresh_token, $expires){},
 	'log_error' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
 
 // for debug you can use
 // $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
-// $params['authUrl'] = 'https://sandbox-business.revolut.com/app-confirm';
 
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
@@ -108,10 +104,7 @@ $revolut = new \ITSOFT\Revolut\Revolut($params);
 ```
 require_once 'revolut.cfg.php';
 
-if(isset($_GET['code']))
- $revolut->exchangeCodeForAccessToken();
-elseif(!$revolut->accessToken)
- $revolut->authLocation();
+if(isset($_GET['code'])) $revolut->exchangeCodeForAccessToken();
   
 //print_r($revolut);
 print "<pre><h2>accounts</h2>\n";

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ $params = [
 ];
 
 
-//for debug you can use
+// for debug you can use
 // $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
+// $params['authUrl'] = 'https://sandbox-business.revolut.com/app-confirm';
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
 ```
@@ -97,8 +98,9 @@ $params = [
 ];
 
 
-//for debug you can use
+// for debug you can use
 // $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
+// $params['authUrl'] = 'https://sandbox-business.revolut.com/app-confirm';
 
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ $params = [
 	'refreshTokenExpires' => $r_token->expires,
 	'saveAccessTokenCb' => function ($access_token, $expires) use ($path2token) {file_put_contents($path2token, json_encode(['access_token' => $access_token, 'expires' => $expires]));},
 	'saveRefreshTokenCb' => function ($refresh_token, $expires) use ($path2refresh_token) {file_put_contents($path2refresh_token, json_encode(['refresh_token' => $refresh_token, 'expires' => $expires]));},
+	'errorUrl' => "/error.php",
 	'logError' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
@@ -89,6 +90,7 @@ $params = [
 	'refreshTokenExpires' => '',
 	'saveAccessTokenCb' => function ($access_token, $expires){},
 	'saveRefreshTokenCb' => function ($refresh_token, $expires){},
+	'errorUrl' => "/error.php",
 	'log_error' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
@@ -98,6 +100,19 @@ $params = [
 
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
+```
+
+### Code for error.php
+```
+<?php
+
+print "<h1>Error</h1>";
+
+if (isset($_GET['msg'])) {
+    print "<pre>";
+    print_r($_GET['msg']);
+    print "</pre>";
+}
 ```
 
 ### Code for OAuth redirect URI (https://your_site.com/redirect_uri/)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ One file. No dependencies for security reasons.
 
 Revolut API has next bugs:
 
-1. Scope does not work. When I ask READ I also can WRITE and send payments. It's shame.
+1. Scope is not supported. When I ask READ I also can WRITE and send payments. It's shame.
 
 2. No possibility to revoke token. Again it's shame. You can ask for new token and not to save it, but it is a crutch.
 
@@ -51,7 +51,6 @@ $a_token = json_decode(file_get_contents($path2token));
 $r_token = json_decode(file_get_contents($path2refresh_token));
 
 $params = [
-	'scope' => 'READ', //WRITE or both
 	'apiUrl' => 'https://b2b.revolut.com/api/1.0', 
 	'clientId' => 'aaasssss....',
 	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
@@ -82,7 +81,6 @@ $ROOT_PATH = '/www/your-crm...';
 
 require_once $ROOT_PATH . 'vendor/autoload.php';
 $params = [
-	'scope' => 'READ', //WRITE or both
 	'apiUrl' => 'https://b2b.revolut.com/api/1.0', 
 	'clientId' => 'aaasssss....',
 	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),

--- a/README.md
+++ b/README.md
@@ -52,23 +52,23 @@ $r_token = json_decode(file_get_contents($path2refresh_token));
 
 $params = [
 	'scope' => 'READ', //WRITE or both
-	'api_url' => 'https://b2b.revolut.com/api/1.0', 
-	'client_id' => 'aaasssss....',
-	'private_key' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
-	'redirect_uri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
+	'apiUrl' => 'https://b2b.revolut.com/api/1.0', 
+	'clientId' => 'aaasssss....',
+	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
+	'redirectUri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
 	'auth_url' => 'https://business.revolut.com/app-confirm', 
-	'access_token' => $a_token->access_token,
-	'access_token_expires' => $a_token->expires,
-	'refresh_token' => $r_token->refresh_token,
-	'refresh_token_expires' => $r_token->expires,
-	'save_access_token' => function ($access_token, $expires) use ($path2token) {file_put_contents($path2token, json_encode(['access_token' => $access_token, 'expires' => $expires]));},
-	'save_refresh_token' => function ($refresh_token, $expires) use ($path2refresh_token) {file_put_contents($path2refresh_token, json_encode(['refresh_token' => $refresh_token, 'expires' => $expires]));},
-	'log_error' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
+	'accessToken' => $a_token->access_token,
+	'accessTokenExpires' => $a_token->expires,
+	'refreshToken' => $r_token->refresh_token,
+	'refreshTokenExpires' => $r_token->expires,
+	'saveAccessToken' => function ($access_token, $expires) use ($path2token) {file_put_contents($path2token, json_encode(['access_token' => $access_token, 'expires' => $expires]));},
+	'saveRefreshToken' => function ($refresh_token, $expires) use ($path2refresh_token) {file_put_contents($path2refresh_token, json_encode(['refresh_token' => $refresh_token, 'expires' => $expires]));},
+	'logError' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
 
 //for debug you can use
-// $params['api_url'] =  'https://sandbox-b2b.revolut.com/api/1.0';
+// $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
 ```
@@ -82,23 +82,23 @@ $ROOT_PATH = '/www/your-crm...';
 require_once $ROOT_PATH . 'vendor/autoload.php';
 $params = [
 	'scope' => 'READ', //WRITE or both
-	'api_url' => 'https://b2b.revolut.com/api/1.0', 
-	'client_id' => 'aaasssss....',
-	'private_key' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
-	'redirect_uri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
+	'apiUrl' => 'https://b2b.revolut.com/api/1.0', 
+	'clientId' => 'aaasssss....',
+	'privateKey' => file_get_contents('your_secret_keys_dir/revolut/privatekey.pem'),
+	'redirectUri' => 'https://your_site.com/redirect_uri/', //OAuth redirect URI
 	'auth_url' => 'https://business.revolut.com/app-confirm', 
-	'access_token' => '',
-	'access_token_expires' => '',
-	'refresh_token' => '',
-	'refresh_token_expires' => '',
-	'save_access_token' => function ($access_token, $expires){},
-	'save_refresh_token' => function ($refresh_token, $expires){},
+	'accessToken' => '',
+	'accessTokenExpires' => '',
+	'refreshToken' => '',
+	'refreshTokenExpires' => '',
+	'saveAccessToken' => function ($access_token, $expires){},
+	'saveRefreshToken' => function ($refresh_token, $expires){},
 	'log_error' => function ($error){mail('your_email@domin.com', 'Revolut API Error', $error);}
 ];
 
 
 //for debug you can use
-// $params['api_url'] =  'https://sandbox-b2b.revolut.com/api/1.0';
+// $params['apiUrl'] =  'https://sandbox-b2b.revolut.com/api/1.0';
 
 
 $revolut = new \ITSOFT\Revolut\Revolut($params);
@@ -110,7 +110,7 @@ require_once 'revolut.cfg.php';
 
 if(isset($_GET['code']))
  $revolut->exchangeCodeForAccessToken();
-elseif(!$revolut->access_token)
+elseif(!$revolut->accessToken)
  $revolut->authLocation();
   
 //print_r($revolut);

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,11 @@
             "role":         "Developer"
         }
     ],
-	"require": {"php": ">=5.4.0"},
+	"require": {
+        "php": ">=5.4.0",
+        "ext-json": "*",
+        "ext-curl": "*",
+        "ext-openssl": "*"
+    },
 	"autoload": {"psr-4": {"ITSOFT\\Revolut\\": "src/"}}
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,12 @@
             "email":    "igor@itsoft.ru",
             "homepage": "https://itsoft.ru",
             "role":     "Developer"
+        },
+        {
+            "name":     "Pavel Maslov",
+            "email":    "pavel.masloff@gmail.com",
+            "homepage": "https://maslick.tech",
+            "role":     "Contributor"
         }
     ],
 	"require": {

--- a/composer.json
+++ b/composer.json
@@ -6,10 +6,10 @@
     "license":          "MIT",
     "authors": [
         {
-            "name":         "Igor Tarasov",
-            "email":        "igor@itsoft.ru",
-            "homepage":     "https://itsoft.ru",
-            "role":         "Developer"
+            "name":     "Igor Tarasov",
+            "email":    "igor@itsoft.ru",
+            "homepage": "https://itsoft.ru",
+            "role":     "Developer"
         }
     ],
 	"require": {
@@ -18,5 +18,7 @@
         "ext-curl": "*",
         "ext-openssl": "*"
     },
-	"autoload": {"psr-4": {"ITSOFT\\Revolut\\": "src/"}}
+	"autoload": {
+        "psr-4": {"ITSOFT\\Revolut\\": "src/"}
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,6 @@
 {
     "name":             "itsoft/revolut",
+    "type":             "library",
     "description":      "Revolut API in one php-class in one file without any dependencies.",
     "keywords":         ["revolut", "api", "php", "single"],
     "homepage":         "https://github.com/itsoft7/revolut-php/",

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,23 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "f00a8a9a0aa3247a5170b0961bd6c9c3",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": ">=5.4.0",
+        "ext-json": "*",
+        "ext-curl": "*",
+        "ext-openssl": "*"
+    },
+    "platform-dev": [],
+    "plugin-api-version": "2.0.0"
+}

--- a/error.php
+++ b/error.php
@@ -1,0 +1,2 @@
+<h1>Error: no token found or refresh token has expired...</h1>
+<h2>Please, go to your Revolut account and Enable API access to your account.</h2>

--- a/error.php
+++ b/error.php
@@ -1,2 +1,9 @@
-<h1>Error: no token found or refresh token has expired...</h1>
-<h2>Please, go to your Revolut account and Enable API access to your account.</h2>
+<?php
+
+print "<h1>Error</h1>";
+
+if (isset($_GET['msg'])) {
+    print "<pre>";
+    print_r($_GET['msg']);
+    print "</pre>";
+}

--- a/error.php
+++ b/error.php
@@ -1,9 +1,0 @@
-<?php
-
-print "<h1>Error</h1>";
-
-if (isset($_GET['msg'])) {
-    print "<pre>";
-    print_r($_GET['msg']);
-    print "</pre>";
-}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -147,4 +147,9 @@
         <exclude-pattern>tests/Core/Tokenizer/StableCommentWhitespaceWinTest\.php</exclude-pattern>
     </rule>
 
+    <rule ref="PSR2">
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
+        <exclude name="Squiz.NamingConventions.ValidVariableName.NotCamelCaps"/>
+    </rule>
+
 </ruleset>

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -1,39 +1,65 @@
 <?php
-
+/**
+ * Revolut PHP SDK
+ *
+ * @author  Igor Tarasov <web@itsoft.ru>
+ * @author  Pavel Maslov <pavel.masloff@gmail.com>
+ * @license https://github.com/itsoft7/revolut-php/blob/master/LICENSE MIT
+ */
 namespace ITSOFT\Revolut;
 
 class Revolut
 {
-
+    /**
+     * Constructor
+     *
+     * @param array $params input parameters
+     */
     public function __construct(array $params)
     {
         foreach ($params as $k => $v) {
             $this->$k = $v;
         }
-
     }
 
+    /**
+     * Base64 encode
+     *
+     * @param string $data input string
+     *
+     * @return string
+     */
     public static function base64urlEncode($data)
-    {return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');}
+    {
+        return rtrim(strtr(base64_encode($data), '+/', '-_'), '=');
+    }
 
+    /**
+     * Create JWT token
+     *
+     * @return string
+     */
     public function getJWT()
     {
-        $header  = ['alg' => 'RS256', 'typ' => 'JWT'];
+        $header  = [
+            'alg' => 'RS256',
+            'typ' => 'JWT',
+        ];
         $payload = [
-            'iss' => parse_url($this->redirect_uri, PHP_URL_HOST),
-            'sub' => $this->client_id,
+            'iss' => parse_url($this->redirectUri, PHP_URL_HOST),
+            'sub' => $this->clientId,
             'aud' => 'https://revolut.com',
-            'exp' => time() + 60 * 60,
+            'exp' => (time() + 60 * 60),
         ];
 
-        $segments    = [];
-        $segments[]  = static::base64urlEncode(json_encode($header));
-        $segments[]  = static::base64urlEncode(json_encode($payload));
-        $signing_str = implode('.', $segments);
+        $segments   = [];
+        $segments[] = static::base64urlEncode(json_encode($header));
+        $segments[] = static::base64urlEncode(json_encode($payload));
+        $signingStr = implode('.', $segments);
 
         $signature = '';
-        $success   = openssl_sign($signing_str, $signature, $this->private_key, 'SHA256');
-        if (!$success) {
+        $success   = openssl_sign($signingStr, $signature, $this->privateKey, 'SHA256');
+        if ($success === false) {
             error_log("openssl_sign returns FALSE.\n");
             exit;
         }
@@ -43,30 +69,41 @@ class Revolut
         return implode('.', $segments);
     }
 
+    /**
+     * Make a HTTP request
+     *
+     * @param string $url     URL
+     * @param string $method  HTTP method
+     * @param string $params  parameters
+     * @param array  $headers headers
+     *
+     * @return string
+     */
     public function curl($url, $method = 'get', $params = '', $headers = [])
     {
         $ch = curl_init();
 
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, false);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 200); //The maximum number of seconds to allow cURL functions to execute.
+        // The maximum number of seconds to allow cURL functions to execute.
+        curl_setopt($ch, CURLOPT_TIMEOUT, 200);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-        if ($method == 'post') {
+        if ($method === 'post') {
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $params);
-        } elseif ($method == 'delete') {
+        } else if ($method === 'delete') {
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "DELETE");
         }
 
         $response = curl_exec($ch);
-        if ($response == false) {
+        if ($response === false) {
             $lastError = curl_error($ch);
-            if (isset($this->log_error)) {
-                $log_error = $this->log_error;
-                $log_error($lastError);
+            if (isset($this->logError) === true) {
+                $logError = $this->logError;
+                $logError($lastError);
             }
 
             return $lastError;
@@ -76,198 +113,337 @@ class Revolut
         return $response;
     }
 
-    public function api($relative_path, $method = 'get', $params = '', $extra_headers = [])
+
+    /**
+     * Call Revolut API
+     *
+     * @param string $relativePath relative path
+     * @param string $method       HTTP method
+     * @param string $params       parameters
+     * @param array  $extraHeaders headers
+     *
+     * @return string
+     */
+    public function api($relativePath, $method = 'get', $params = '', $extraHeaders = [])
     {
-        if (!$this->access_token) {
+        if ($this->accessToken === false) {
             $this->authLocation();
-        } elseif (time() > $this->access_token_expires - 30) {
+        } else if (time() > ($this->accessTokenExpires - 30)) {
             $this->refreshAccessToken();
         }
 
-        $url = $this->api_url . $relative_path;
+        $url = $this->apiUrl.$relativePath;
 
-        if ($method == 'get') {
-            if ($params) {
-                $url .= '?' . http_build_query($params);
+        if ($method === 'get') {
+            if ($params === true) {
+                $url .= '?'.http_build_query($params);
             }
-
         } else {
             $params = json_encode($params);
         }
 
-        $headers = array(
+        $headers = [
             'Content-Type: application/json',
             'Accept: application/json',
-            'Authorization: Bearer ' . $this->access_token,
-        );
-        $headers = array_merge($headers, $extra_headers);
+            'Authorization: Bearer '.$this->accessToken,
+        ];
+        $headers = array_merge($headers, $extraHeaders);
         $data    = $this->curl($url, $method, $params, $headers);
         $data    = json_decode($data);
         return $data;
     }
 
+    /**
+     * Create a confirmation URL
+     *
+     * @return string
+     */
     public function authUri()
     {
         $params = [
-            'client_id'     => $this->client_id,
+            'client_id'     => $this->clientId,
             'response_type' => 'code',
-            'redirect_uri'  => $this->redirect_uri,
+            'redirect_uri'  => $this->redirectUri,
             'scope'         => $this->scope,
         ];
-        return 'https://business.revolut.com/app-confirm?' . http_build_query($params);
+        return 'https://business.revolut.com/app-confirm?'.http_build_query($params);
     }
 
+    /**
+     * Go to confirmation URL
+     *
+     * @return string
+     */
     public function authLocation()
     {
         $uri = $this->authUri();
-        header('Location: ' . $uri);
+        header('Location: '.$uri);
         exit;
     }
 
+    /**
+     * Exchange code for access token
+     *
+     * @return string
+     */
     public function exchangeCodeForAccessToken()
     {
         $params = [
             'grant_type'            => 'authorization_code',
             'code'                  => $_GET['code'],
-            'client_id'             => $this->client_id,
+            'client_id'             => $this->clientId,
             'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
             'client_assertion'      => $this->getJWT(),
         ];
 
-        $url     = $this->api_url . '/auth/token';
+        $url     = $this->apiUrl.'/auth/token';
         $params  = http_build_query($params);
         $headers = ['Content-Type: application/x-www-form-urlencoded'];
         $data    = $this->curl($url, 'post', $params, $headers);
         $data    = json_decode($data);
 
-        if ($data->access_token) {
-            $this->access_token          = $data->access_token;
-            $this->refresh_token         = $data->refresh_token;
-            $this->access_token_expires  = time() + $data->expires_in;
-            $this->refresh_token_expires = time() + 90 * 24 * 60 * 60;
+        if (strlen($data->access_token) > 0) {
+            $this->accessToken         = $data->access_token;
+            $this->refreshToken        = $data->refresh_token;
+            $this->accessTokenExpires  = (time() + $data->expires_in);
+            $this->refreshTokenExpires = (time() + 90 * 24 * 60 * 60);
 
-            $save_access_token = $this->save_access_token;
-            $save_access_token($this->access_token, $this->access_token_expires);
-            $save_refresh_token = $this->save_refresh_token;
-            $save_refresh_token($this->refresh_token, $this->refresh_token_expires);
+            $saveAccessToken = $this->saveAccessToken;
+            $saveAccessToken($this->accessToken, $this->accessTokenExpires);
+            $saveRefreshToken = $this->saveRefreshToken;
+            $saveRefreshToken($this->refreshToken, $this->refreshTokenExpires);
         } else {
             error_log(print_r($data, true));
             $this->authLocation();
         }
     }
 
+    /**
+     * Refresh access token
+     *
+     * @return string
+     */
     public function refreshAccessToken()
     {
-        if (time() > $this->refresh_token_expires - 30) {
+        if (time() > ($this->refreshTokenExpires - 30)) {
             $this->authLocation();
         }
 
         $params = [
             'grant_type'            => 'refresh_token',
-            'refresh_token'         => $this->refresh_token,
-            'client_id'             => $this->client_id,
+            'refresh_token'         => $this->refreshToken,
+            'client_id'             => $this->clientId,
             'client_assertion_type' => 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
             'client_assertion'      => $this->getJWT(),
         ];
 
-        $url                        = $this->api_url . '/auth/token';
-        $params                     = http_build_query($params);
-        $headers                    = ['Content-Type: application/x-www-form-urlencoded'];
-        $data                       = $this->curl($url, 'post', $params, $headers);
-        $data                       = json_decode($data);
-        $this->access_token         = $data->access_token;
-        $this->access_token_expires = time() + $data->expires_in;
+        $url     = $this->apiUrl.'/auth/token';
+        $params  = http_build_query($params);
+        $headers = ['Content-Type: application/x-www-form-urlencoded'];
+        $data    = $this->curl($url, 'post', $params, $headers);
+        $data    = json_decode($data);
+        $this->accessToken        = $data->access_token;
+        $this->accessTokenExpires = (time() + $data->expires_in);
 
-        $save_access_token = $this->save_access_token;
-        $save_access_token($this->access_token, $this->access_token_expires);
+        $saveAccessToken = $this->saveAccessToken;
+        $saveAccessToken($this->accessToken, $this->accessTokenExpires);
     }
 
+    /**
+     * Get accounts
+     *
+     * @return string
+     */
     public function accounts()
     {
         return $this->api('/accounts');
     }
 
+    /**
+     * Get account
+     *
+     * @param string $id account id
+     *
+     * @return string
+     */
     public function account($id)
     {
-        return $this->api('/accounts/' . $id);
+        return $this->api('/accounts/'.$id);
     }
 
+    /**
+     * Get account details
+     *
+     * @param string $id account id
+     *
+     * @return string
+     */
     public function accountDetails($id)
     {
-        return $this->api('/accounts/' . $id . '/bank-details');
+        return $this->api('/accounts/'.$id.'/bank-details');
     }
 
-/**
- * If in $params is address, all address fields must be.
- */
+    /**
+     * Add a counterparty
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function addCounterparty($params)
     {
         return $this->api('/counterparty', 'post', $params);
     }
 
+    /**
+     * Delete a counterparty
+     *
+     * @param string $counterparty counterparty id
+     *
+     * @return mixed
+     */
     public function deleteCounterparty($counterparty)
     {
-        return $this->api('/counterparty/' . $counterparty, 'delete');
+        return $this->api('/counterparty/'.$counterparty, 'delete');
     }
 
+    /**
+     * Get a counterparty
+     *
+     * @param string $counterparty counterparty id
+     *
+     * @return mixed
+     */
     public function getCounterparty($counterparty)
     {
-        return $this->api('/counterparty/' . $counterparty);
+        return $this->api('/counterparty/'.$counterparty);
     }
 
+    /**
+     * Get all counterparties
+     *
+     * @return mixed
+     */
     public function counterparties()
     {
         return $this->api('/counterparties');
     }
 
+    /**
+     * Create a payment
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function createPayment($params)
     {
         return $this->api('/pay', 'post', $params);
     }
 
+    /**
+     * Get transactions
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function transactions($params = null)
     {
         return $this->api('/transactions', 'get', $params);
     }
 
+    /**
+     * Get a transaction
+     *
+     * @param string $id transaction id
+     *
+     * @return mixed
+     */
     public function transaction($id)
     {
-        return $this->api('/transaction/' . $id);
+        return $this->api('/transaction/'.$id);
     }
 
+    /**
+     * Create a transfer
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function createTransfer($params)
     {
         return $this->api('/transfer', 'post', $params);
     }
 
+    /**
+     * Create a payment draft
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function createPaymentDraft($params)
     {
         return $this->api('/payment-drafts', 'post', $params);
     }
 
+    /**
+     * Delete a payment draft
+     *
+     * @param string $id payment draft id
+     *
+     * @return mixed
+     */
     public function deletePaymentDraft($id)
     {
-        return $this->api('/payment-drafts/' . $id, 'delete');
+        return $this->api('/payment-drafts/'.$id, 'delete');
     }
 
+    /**
+     * Get all payment drafts
+     *
+     * @return mixed
+     */
     public function paymentDrafts()
     {
         return $this->api('/payment-drafts');
     }
 
+    /**
+     * Get a payment draft
+     *
+     * @param string $id payment draft id
+     *
+     * @return mixed
+     */
     public function paymentDraft($id)
     {
-        return $this->api('/payment-drafts/' . $id);
+        return $this->api('/payment-drafts/'.$id);
     }
 
+    /**
+     * Get exchange rate
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function getExchangeRate($params)
     {
         return $this->api('/rate', 'get', $params);
     }
 
+    /**
+     * Exchange money
+     *
+     * @param object $params parameters
+     *
+     * @return mixed
+     */
     public function exchangeMoney($params)
     {
         return $this->api('/exchange', 'post', $params);
     }
-
 }

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -206,7 +206,7 @@ class Revolut
     {
         if (strlen($this->accessToken) === 0) {
             error_log("No token available");
-            $this->goToLocation($this->errorUrl);
+            $this->goToLocation($this->errorUrl, "No token found. Go to Developer Settings and Enable API access.");
         } else if (time() > ($this->accessTokenExpires - 30)) {
             error_log("Token has expired");
             $this->refreshAccessToken();
@@ -215,7 +215,7 @@ class Revolut
         $url = $this->apiUrl.$relativePath;
 
         if ($method === 'get') {
-            if ($params === true) {
+            if (isset($params) === true) {
                 $url .= '?'.http_build_query($params);
             }
         } else {
@@ -237,12 +237,17 @@ class Revolut
      * Go to a location
      *
      * @param $location string URL e.g. http://localhost:8080/hello.php
+     * @param string $error    optional error message
      *
      * @return string
      */
-    public function goToLocation($location)
+    public function goToLocation($location, $error = '')
     {
-        header('Location: '.$location);
+        if (strlen($error) > 0) {
+            header('Location: '.$location."?msg=".$error);
+        } else {
+            header('Location: '.$location);
+        }
         exit;
     }
 
@@ -293,7 +298,7 @@ class Revolut
         error_log("Refreshing access token...");
         if (time() > ($this->refreshTokenExpires - 30)) {
             error_log("Refresh token has expired");
-            $this->goToLocation($this->errorUrl);
+            $this->goToLocation($this->errorUrl, "Refresh token has expired. Go to Developer Settings and Enable API access.");
         }
 
         $params = [

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -37,7 +37,7 @@ class Revolut
      *
      * @var string
      */
-    private $accessToken;
+    public $accessToken;
 
     /**
      * Epoch time when access token expires

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -173,7 +173,7 @@ class Revolut
         $url                        = $this->api_url . '/auth/token';
         $params                     = http_build_query($params);
         $headers                    = ['Content-Type: application/x-www-form-urlencoded'];
-        $data                       = $this->curl($url, 'post', $params, $header);
+        $data                       = $this->curl($url, 'post', $params, $headers);
         $data                       = json_decode($data);
         $this->access_token         = $data->access_token;
         $this->access_token_expires = time() + $data->expires_in;

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -10,6 +10,84 @@ namespace ITSOFT\Revolut;
 
 class Revolut
 {
+
+    /**
+     * Redirect url
+     *
+     * @var string
+     */
+    private $redirectUri;
+
+    /**
+     * Revolut client id
+     *
+     * @var string
+     */
+    private $clientId;
+
+    /**
+     * Revolut private key
+     *
+     * @var string
+     */
+    private $privateKey;
+
+    /**
+     * Revolut access token
+     *
+     * @var string
+     */
+    private $accessToken;
+
+    /**
+     * Epoch time when access token expires
+     *
+     * @var numeric
+     */
+    private $accessTokenExpires;
+
+    /**
+     * Revolut refresh token
+     *
+     * @var string
+     */
+    private $refreshToken;
+
+    /**
+     * Epoch time when refresh token expires
+     *
+     * @var string
+     */
+    private $refreshTokenExpires;
+
+    /**
+     * Revolut API base URL (e.g. https://b2b.revolut.com/api/1.0)
+     *
+     * @var string
+     */
+    private $apiUrl;
+
+    /**
+     * Revolut OAuth scope
+     *
+     * @var string
+     */
+    private $scope;
+
+    /**
+     * Callback function has input 2 parameters - $access_token and $expires
+     *
+     * @var callable
+     */
+    private $saveAccessToken;
+
+    /**
+     * Callback function has input 2 parameters - $access_token and $expires
+     *
+     * @var callable
+     */
+    private $saveRefreshToken;
+
     /**
      * Constructor
      *

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -2,7 +2,7 @@
 /**
  * Revolut PHP SDK
  *
- * @author  Igor Tarasov <web@itsoft.ru>
+ * @author  Igor Tarasov <igor@itsoft.ru>
  * @author  Pavel Maslov <pavel.masloff@gmail.com>
  * @license https://github.com/itsoft7/revolut-php/blob/master/LICENSE MIT
  */

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -68,6 +68,13 @@ class Revolut
     private $apiUrl;
 
     /**
+     * Base URL to enable access to your Revolut account
+     *
+     * @var string
+     */
+    private $authUrl;
+
+    /**
      * Revolut OAuth scope
      *
      * @var string
@@ -244,7 +251,7 @@ class Revolut
             'redirect_uri'  => $this->redirectUri,
             'scope'         => $this->scope,
         ];
-        return 'https://business.revolut.com/app-confirm?'.http_build_query($params);
+        return $this->authUrl.'?'.http_build_query($params);
     }
 
     /**

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -75,13 +75,6 @@ class Revolut
     private $authUrl;
 
     /**
-     * Revolut OAuth scope
-     *
-     * @var string
-     */
-    private $scope;
-
-    /**
      * Callback function has input 2 parameters - $access_token and $expires
      *
      * @var callable
@@ -120,7 +113,8 @@ class Revolut
     }
 
     /**
-     * Create JWT token
+     * Generate a client-assertion JWT that you use to exchange your authorization code for access token.
+     * The client-assertion JWT should be signed with your private key.
      *
      * @return string
      */
@@ -198,7 +192,6 @@ class Revolut
         return $response;
     }
 
-
     /**
      * Call Revolut API
      *
@@ -247,9 +240,8 @@ class Revolut
     {
         $params = [
             'client_id'     => $this->clientId,
-            'response_type' => 'code',
             'redirect_uri'  => $this->redirectUri,
-            'scope'         => $this->scope,
+            'response_type' => 'code',
         ];
         return $this->authUrl.'?'.http_build_query($params);
     }
@@ -267,7 +259,7 @@ class Revolut
     }
 
     /**
-     * Exchange code for access token
+     * Exchange authorization code for access token
      *
      * @return void
      */
@@ -304,7 +296,7 @@ class Revolut
     }
 
     /**
-     * Refresh access token
+     * After the access token expires, use the refresh_token to request a new one.
      *
      * @return void
      */

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -511,7 +511,7 @@ class Revolut
     /**
      * Get exchange rate
      *
-     * @param object $params parameters
+     * @param array $params parameters
      *
      * @return mixed
      */

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -197,12 +197,12 @@ class Revolut
      *
      * @param string $relativePath relative path
      * @param string $method       HTTP method
-     * @param string $params       parameters
+     * @param array  $params       parameters
      * @param array  $extraHeaders headers
      *
      * @return string
      */
-    public function api($relativePath, $method = 'get', $params = '', $extraHeaders = [])
+    public function api($relativePath, $method = 'get', $params = [], $extraHeaders = [])
     {
         if (strlen($this->accessToken) === 0) {
             error_log("No token available");

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -262,7 +262,7 @@ class Revolut
     /**
      * Exchange code for access token
      *
-     * @return string
+     * @return void
      */
     public function exchangeCodeForAccessToken()
     {
@@ -299,7 +299,7 @@ class Revolut
     /**
      * Refresh access token
      *
-     * @return string
+     * @return void
      */
     public function refreshAccessToken()
     {

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -204,7 +204,7 @@ class Revolut
      */
     public function api($relativePath, $method = 'get', $params = [], $extraHeaders = [])
     {
-        if (strlen($this->accessToken) === 0) {
+        if (isset($this->accessToken) === false && strlen($this->accessToken) === 0) {
             error_log("No token available");
             $this->goToLocation($this->errorUrl, "No token found. Go to Developer Settings and Enable API access.");
         } else if (time() > ($this->accessTokenExpires - 30)) {

--- a/src/Revolut.php
+++ b/src/Revolut.php
@@ -204,7 +204,7 @@ class Revolut
      */
     public function api($relativePath, $method = 'get', $params = [], $extraHeaders = [])
     {
-        if (isset($this->accessToken) === false && strlen($this->accessToken) === 0) {
+        if (strlen($this->accessToken) === 0) {
             error_log("No token available");
             $this->goToLocation($this->errorUrl, "No token found. Go to Developer Settings and Enable API access.");
         } else if (time() > ($this->accessTokenExpires - 30)) {


### PR DESCRIPTION
* fixing a small bug in refreshAccessToken()
* access token is valid for 40 min, and not 60 min
* removed scope, because it's not supported
* added redirect to a custom error endpoint (i.e. error.php)
* first token/refresh pair can be done via Revolut Developer Console -> removed authLocation()
* camelCase variable and method names
* making builds green again (php lint)
* added some documentation
* overall improvements, readability, etc.

I have created a demo app https://github.com/maslick/revolutor